### PR TITLE
Fix ZIndex on Expand/Select Buttons

### DIFF
--- a/src/Components/Preview.lua
+++ b/src/Components/Preview.lua
@@ -150,6 +150,7 @@ function Preview:render()
 			BackgroundTransparency = 1,
 			Position = UDim2.fromScale(0.99, 0.99),
 			Size = UDim2.fromOffset(40, 40),
+			ZIndex = 2,
 		}, {
 			Button = e(FloatingButton, {
 				Activated = self.openSelection,
@@ -164,6 +165,7 @@ function Preview:render()
 			BackgroundTransparency = 1,
 			Position = UDim2.new(0.99, -45, 0.99),
 			Size = UDim2.fromOffset(40, 40),
+			ZIndex = 2,
 		}, {
 			Button = e(FloatingButton, {
 				Activated = self.expandSelection,


### PR DESCRIPTION
Solves this issue, where the preview overlaps with the Hoarcekat buttons.
This increases the ZIndes of the Selection and Expansion button, so that they will always appear on top.

![image](https://user-images.githubusercontent.com/46231745/117534456-a9a00280-b045-11eb-9233-18d867e70283.png)
