### PR TITLE
Fix ZIndexBehaviour on expanded preview

### DIFF
--- a/src/Components/Preview.lua
+++ b/src/Components/Preview.lua
@@ -24,6 +24,7 @@ function Preview:init()
 
 	local display = Instance.new("ScreenGui")
 	display.Name = "HoarcekatDisplay"
+	display.ZIndexBehavior = Enum.ZIndexBehavior.Sibling
 	self.display = display
 
 	self.expand = false


### PR DESCRIPTION
This PR fixes an issue with the expanded preview button, where it does not use the Sibling `ZIndexBehaviour` that the Hoarcekat preview does.

Example before this PR (broken):
https://user-images.githubusercontent.com/46231745/138583972-64d0fb47-06a5-4db8-be1a-1d0e272ed6f9.mp4

Example after this PR (intended):
https://user-images.githubusercontent.com/46231745/138583942-84fa0de7-0222-42f6-b79d-adf31671608e.mp4


