### PR TITLE
Fix refresh breaking when story produces an error.

### DIFF
--- a/src/Components/Preview.lua
+++ b/src/Components/Preview.lua
@@ -34,6 +34,10 @@ function Preview:init()
 			return self.monkeyRequireCache[otherScript]
 		end
 
+		self.monkeyRequireMaid:GiveTask(otherScript.Changed:connect(function()
+			self:refreshPreview()
+		end))
+
 		-- loadstring is used to avoid cache while preserving `script` (which requiring a clone wouldn't do)
 		local result, parseError = loadstring(otherScript.Source, otherScript:GetFullName())
 		if result == nil then
@@ -53,10 +57,6 @@ function Preview:init()
 
 		local output = result()
 		self.monkeyRequireCache[otherScript] = output
-
-		self.monkeyRequireMaid:GiveTask(otherScript.Changed:connect(function()
-			self:refreshPreview()
-		end))
 
 		return output
 	end


### PR DESCRIPTION
When a story throws an error, the live refresh fails until the user
reselects the story. This happens because the setup of the Changed
event occurs after parsing the story source. If parsing fails, then the
function returns before the Changed event is ever set up.

This change simply moves setup of the Changed event to occur before
parsing.