### PR TITLE
Improve error handling for live editing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Improved live editing experience by retaining last working preview and delaying error messages. ([#27](https://github.com/Kampfkarren/hoarcekat/pull/27))
+
 ### Fixed
 - Fixed expanded UI not using sibling ZIndexBehavior, like the un-expanded UI. ([#24](https://github.com/Kampfkarren/hoarcekat/pull/24))
 - Fixed the expand/select buttons being layered behind stories. ([#21](https://github.com/Kampfkarren/hoarcekat/pull/21))

--- a/src/Components/Preview.lua
+++ b/src/Components/Preview.lua
@@ -15,12 +15,10 @@ local e = Roact.createElement
 local Preview = Roact.PureComponent:extend("Preview")
 
 function Preview:init()
-	self.previewRef = Roact.createRef()
+	self.rootRef = Roact.createRef()
 
-	self.monkeyRequireCache = {}
-	self.monkeyRequireMaid = Maid.new()
-
-	self.monkeyGlobalTable = {}
+	self.currentPreview = nil
+	self.errorID = 0
 
 	local display = Instance.new("ScreenGui")
 	display.Name = "HoarcekatDisplay"
@@ -29,42 +27,9 @@ function Preview:init()
 
 	self.expand = false
 
-	self.monkeyRequire = function(otherScript)
-		if self.monkeyRequireCache[otherScript] then
-			return self.monkeyRequireCache[otherScript]
-		end
-
-		self.monkeyRequireMaid:GiveTask(otherScript.Changed:connect(function()
-			self:refreshPreview()
-		end))
-
-		-- loadstring is used to avoid cache while preserving `script` (which requiring a clone wouldn't do)
-		local result, parseError = loadstring(otherScript.Source, otherScript:GetFullName())
-		if result == nil then
-			error(("Could not parse %s: %s"):format(otherScript:GetFullName(), parseError))
-			return
-		end
-
-		local fenv = setmetatable({
-			require = self.monkeyRequire,
-			script = otherScript,
-			_G = self.monkeyGlobalTable,
-		}, {
-			__index = getfenv(),
-		})
-
-		setfenv(result, fenv)
-
-		local output = result()
-		self.monkeyRequireCache[otherScript] = output
-
-		return output
-	end
-
 	self.openSelection = function()
-		local preview = self.previewRef:getValue()
-		if preview then
-			Selection:Set({ preview })
+		if self.currentPreview and self.currentPreview.target then
+			Selection:Set({ self.currentPreview.target })
 		end
 	end
 
@@ -72,7 +37,7 @@ function Preview:init()
 		self.expand = not self.expand
 		self.display.Parent = self.expand and CoreGui or nil
 
-		self:refreshPreview()
+		self:updateDisplay()
 	end
 end
 
@@ -85,47 +50,147 @@ function Preview:didUpdate()
 end
 
 function Preview:willUnmount()
-	self.monkeyRequireMaid:DoCleaning()
+	self:clearPreview()
+end
+
+local ERROR_DELAY = 1
+function Preview:setError(err)
+	local id = self.errorID + 1
+	self.errorID = id
+	task.delay(ERROR_DELAY, function()
+		if self.errorID ~= id then
+			-- Error was canceled or replaced.
+			return
+		end
+		warn(err)
+	end)
+end
+
+function Preview:cancelError()
+	self.errorID += 1
+end
+
+function Preview:updateDisplay()
+	if not self.currentPreview then
+		return
+	end
+	local target = self.currentPreview.target
+	if not target then
+		return
+	end
+	if self.expand then
+		target.Parent = self.display
+	else
+		target.Parent = self.rootRef:getValue()
+	end
 end
 
 function Preview:refreshPreview()
-	if self.cleanup then
-		local ok, result = pcall(self.cleanup)
-		if not ok then
-			warn("Error cleaning up story: " .. result)
-		end
-
-		self.cleanup = nil
-	end
-
-	local preview = self.previewRef:getValue()
-	if preview ~= nil then
-		preview:ClearAllChildren()
-	end
-
 	local selectedStory = self.props.selectedStory
-	if selectedStory then
-		self.monkeyRequireCache = {}
-		self.monkeyGlobalTable = {}
+	if not selectedStory then
+		self:clearPreview()
+		return
+	end
+	local err, nextState = self:prepareState(selectedStory)
+	if err then
+		self:setError(err)
+		return
+	end
+	self:clearPreview()
+	self.currentPreview = nextState
+	self:updateDisplay()
+end
+
+function Preview:clearPreview()
+	self:cancelError()
+	local state = self.currentPreview
+	if state == nil then
+		return
+	end
+	state:destroy()
+	self.currentPreview = nil
+end
+
+function Preview:prepareState(selectedStory)
+	local state = {
+		cleanup = nil,
+		monkeyRequireCache = {},
+		monkeyGlobalTable = {},
+		monkeyRequireMaid = Maid.new(),
+		target = nil,
+	}
+
+	function state:destroy()
 		self.monkeyRequireMaid:DoCleaning()
 
-		local requireOk, result = xpcall(self.monkeyRequire, debug.traceback, selectedStory)
-		if not requireOk then
-			warn("Error requiring story: " .. result)
-			return
+		if self.cleanup then
+			local ok, result = pcall(self.cleanup)
+			if not ok then
+				warn("Error cleaning up story: " .. result)
+			end
+
+			self.cleanup = nil
 		end
 
-		local execOk, cleanup = xpcall(function()
-			return result(self.expand and self.display or self.previewRef:getValue())
-		end, debug.traceback)
-
-		if not execOk then
-			warn("Error executing story: " .. cleanup)
-			return
+		if self.target then
+			self.target:Destroy()
 		end
-
-		self.cleanup = cleanup
 	end
+
+	local function monkeyRequire(otherScript)
+		if state.monkeyRequireCache[otherScript] then
+			return state.monkeyRequireCache[otherScript]
+		end
+
+		state.monkeyRequireMaid:GiveTask(otherScript.Changed:connect(function()
+			self:refreshPreview()
+		end))
+
+		-- loadstring is used to avoid cache while preserving `script` (which requiring a clone wouldn't do)
+		local result, parseError = loadstring(otherScript.Source, otherScript:GetFullName())
+		if result == nil then
+			error(("Could not parse %s: %s"):format(otherScript:GetFullName(), parseError))
+			return
+		end
+
+		local fenv = setmetatable({
+			require = monkeyRequire,
+			script = otherScript,
+			_G = state.monkeyGlobalTable,
+		}, {
+			__index = getfenv(),
+		})
+
+		setfenv(result, fenv)
+
+		local output = result()
+		state.monkeyRequireCache[otherScript] = output
+
+		return output
+	end
+
+	local requireOk, result = xpcall(monkeyRequire, debug.traceback, selectedStory)
+	if not requireOk then
+		state:destroy()
+		return "Error requiring story: " .. result, nil
+	end
+
+	state.target = Instance.new("Frame")
+	state.target.Name = "Preview"
+	state.target.BackgroundTransparency = 1
+	state.target.Size = UDim2.fromScale(1, 1)
+
+	local execOk, cleanup = xpcall(function()
+		return result(state.target)
+	end, debug.traceback)
+
+	if not execOk then
+		state:destroy()
+		return "Error executing story: " .. cleanup, nil
+	end
+
+	state.cleanup = cleanup
+	return nil, state
 end
 
 function Preview:render()
@@ -134,16 +199,11 @@ function Preview:render()
 	return e("Frame", {
 		BackgroundTransparency = 1,
 		Size = UDim2.fromScale(1, 1),
+		[Roact.Ref] = self.rootRef,
 	}, {
 		UIPadding = e("UIPadding", {
 			PaddingLeft = UDim.new(0, 5),
 			PaddingTop = UDim.new(0, 5),
-		}),
-
-		Preview = e("Frame", {
-			BackgroundTransparency = 1,
-			Size = UDim2.fromScale(1, 1),
-			[Roact.Ref] = self.previewRef,
 		}),
 
 		SelectButton = e("Frame", {


### PR DESCRIPTION
When editing a story, the source will usually be in an invalid state
temporarily. Because the preview updates immediately on change, these
error states are detected, emitting errors on each key press, leading
to a poor editing experience.

The Preview component has been changed to delay the error for a short
time, giving the user time to bring the story into a valid state. The
error will only be emitted if the story remains in an invalid state
after it has not been modified for this time.

Additionally, while the story has an error, the last working preview
will continue to operate.

This behavior is implemented by isolating the state of previews. When a
preview is refreshed, a new preview is prepared without interrupting
the current one. If this preview fails, the current one is unaffected,
and an error is set to be emitted later. If the next preview succeeds,
it is immediately swapped in, and any pending error is canceled.

Because the next preview is prepared before the current preview is
cleared, target frames are generated per preview instead of having a
constant target.