### PR TITLE
Splitter control to resize stories list / preview pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Vertical splitter bar between Stories list and Preview pane which can be dragged to resize the two areas.
+
 ## [1.2.1]
 ### Changed
 - Improved live editing experience by retaining last working preview and delaying error messages. ([#27](https://github.com/Kampfkarren/hoarcekat/pull/27))

--- a/src/Components/App.lua
+++ b/src/Components/App.lua
@@ -4,6 +4,7 @@ local Roact = require(Hoarcekat.Vendor.Roact)
 
 local Preview = require(script.Parent.Preview)
 local Sidebar = require(script.Parent.Sidebar)
+local VerticalSplitter = require(script.Parent.VerticalSplitter)
 local StudioThemeAccessor = require(script.Parent.StudioThemeAccessor)
 
 local e = Roact.createElement
@@ -15,20 +16,9 @@ local function App()
 				BackgroundColor3 = theme:GetColor("MainBackground", "Default"),
 				Size = UDim2.fromScale(1, 1),
 			}, {
-				Sidebar = e("Frame", {
-					BackgroundTransparency = 1,
-					Size = UDim2.fromScale(0.2, 1),
-				}, {
-					Sidebar = e(Sidebar),
-				}),
-
-				Preview = e("Frame", {
-					AnchorPoint = Vector2.new(1, 0),
-					BackgroundTransparency = 1,
-					Position = UDim2.fromScale(1, 0),
-					Size = UDim2.fromScale(0.8, 1),
-				}, {
-					Preview = e(Preview),
+				Splitter = e(VerticalSplitter, {}, {
+					Left = e(Sidebar),
+					Right = e(Preview),
 				}),
 			})
 		end,

--- a/src/Components/App.lua
+++ b/src/Components/App.lua
@@ -9,14 +9,16 @@ local StudioThemeAccessor = require(script.Parent.StudioThemeAccessor)
 
 local e = Roact.createElement
 
-local function App()
+local function App(props)
 	return e(StudioThemeAccessor, {}, {
 		function(theme)
 			return e("Frame", {
 				BackgroundColor3 = theme:GetColor("MainBackground", "Default"),
 				Size = UDim2.fromScale(1, 1),
 			}, {
-				Splitter = e(VerticalSplitter, {}, {
+				Splitter = e(VerticalSplitter, {
+					Mouse = props.Mouse,
+				}, {
 					Left = e(Sidebar),
 					Right = e(Preview),
 				}),

--- a/src/Components/VerticalSplitter.lua
+++ b/src/Components/VerticalSplitter.lua
@@ -1,8 +1,10 @@
 local Hoarcekat = script:FindFirstAncestor("Hoarcekat")
+local Plugin = script:FindFirstAncestorWhichIsA("Plugin")
 
 local Roact = require(Hoarcekat.Vendor.Roact)
 local StudioThemeAccessor = require(script.Parent.StudioThemeAccessor)
 
+local pluginMouse = Plugin:GetMouse()
 local e = Roact.createElement
 
 local HANDLE_WIDTH = 4
@@ -54,6 +56,22 @@ function VerticalSplitter:init()
 			end
 		end
 	end
+end
+
+function VerticalSplitter:updateMouseIcon()
+	if self.state.hovering or self.state.dragging then
+		pluginMouse.Icon = "rbxasset://SystemCursors/SplitEW"
+	else
+		pluginMouse.Icon = "rbxasset://SystemCursors/Arrow"
+	end
+end
+
+function VerticalSplitter:didUpdate()
+	self:updateMouseIcon()
+end
+
+function VerticalSplitter:willUnmount()
+	self:updateMouseIcon()
 end
 
 function VerticalSplitter:render()

--- a/src/Components/VerticalSplitter.lua
+++ b/src/Components/VerticalSplitter.lua
@@ -1,10 +1,8 @@
 local Hoarcekat = script:FindFirstAncestor("Hoarcekat")
-local Plugin = script:FindFirstAncestorWhichIsA("Plugin")
 
 local Roact = require(Hoarcekat.Vendor.Roact)
 local StudioThemeAccessor = require(script.Parent.StudioThemeAccessor)
 
-local pluginMouse = Plugin:GetMouse()
 local e = Roact.createElement
 
 local HANDLE_WIDTH = 4
@@ -59,10 +57,11 @@ function VerticalSplitter:init()
 end
 
 function VerticalSplitter:updateMouseIcon()
+	local pluginMouse = self.props.Mouse
 	if self.state.hovering or self.state.dragging then
 		pluginMouse.Icon = "rbxasset://SystemCursors/SplitEW"
 	else
-		pluginMouse.Icon = "rbxasset://SystemCursors/Arrow"
+		pluginMouse.Icon = "" -- empty string resets mouse icon
 	end
 end
 

--- a/src/Components/VerticalSplitter.lua
+++ b/src/Components/VerticalSplitter.lua
@@ -47,9 +47,10 @@ function VerticalSplitter:init()
 		if input.UserInputType == Enum.UserInputType.MouseMovement then
 			if self.state.dragging == true then
 				local container = self.containerRef:getValue()
-				local offset = input.Position.x - container.AbsolutePosition.x
 				local width = container.AbsoluteSize.x
-				self:setState({ alpha = math.clamp(offset / width, 0, 1) })
+				local offset = input.Position.x - container.AbsolutePosition.x
+				offset = math.clamp(offset, HANDLE_WIDTH, width - HANDLE_WIDTH)
+				self:setState({ alpha = offset / width })
 			end
 		end
 	end

--- a/src/Components/VerticalSplitter.lua
+++ b/src/Components/VerticalSplitter.lua
@@ -1,0 +1,116 @@
+local Hoarcekat = script:FindFirstAncestor("Hoarcekat")
+
+local Roact = require(Hoarcekat.Vendor.Roact)
+local StudioThemeAccessor = require(script.Parent.StudioThemeAccessor)
+
+local e = Roact.createElement
+
+local HANDLE_WIDTH = 4
+local DEFAULT_ALPHA = 0.2
+
+--[[
+ideally this component would not have a hard-coded default alpha or self-contained alpha state
+instead, it would accept initial/current alpha as a prop, which would enable a persistent layout
+however, we don't need that here and it isn't worth the added complexity
+]]
+
+local VerticalSplitter = Roact.Component:extend("VerticalSplitter")
+
+VerticalSplitter.defaultProps = {
+	Size = UDim2.fromScale(1, 1),
+	Position = UDim2.fromScale(0, 0),
+	AnchorPoint = Vector2.new(0, 0),
+}
+
+function VerticalSplitter:init()
+	self.containerRef = Roact.createRef()
+	self:setState({
+		hovering = false,
+		dragging = false,
+		alpha = DEFAULT_ALPHA,
+	})
+	self.onInputBegan = function(_rbx, input)
+		if input.UserInputType == Enum.UserInputType.MouseMovement then
+			self:setState({ hovering = true })
+		elseif input.UserInputType == Enum.UserInputType.MouseButton1 then
+			self:setState({ dragging = true })
+		end
+	end
+	self.onInputEnded = function(_rbx, input)
+		if input.UserInputType == Enum.UserInputType.MouseMovement then
+			self:setState({ hovering = false })
+		elseif input.UserInputType == Enum.UserInputType.MouseButton1 then
+			self:setState({ dragging = false })
+		end
+	end
+	self.onInputChanged = function(_rbx, input)
+		if input.UserInputType == Enum.UserInputType.MouseMovement then
+			if self.state.dragging == true then
+				local container = self.containerRef:getValue()
+				local offset = input.Position.x - container.AbsolutePosition.x
+				local width = container.AbsoluteSize.x
+				self:setState({ alpha = math.clamp(offset / width, 0, 1) })
+			end
+		end
+	end
+end
+
+function VerticalSplitter:render()
+	return e(StudioThemeAccessor, {}, {
+		function(theme)
+			return e("Frame", {
+				Size = self.props.Size,
+				Position = self.props.Position,
+				AnchorPoint = self.props.AnchorPoint,
+				ZIndex = self.props.ZIndex,
+				LayoutOrder = self.props.LayoutOrder,
+				BackgroundTransparency = 1,
+				[Roact.Ref] = self.containerRef,
+				[Roact.Event.InputChanged] = self.onInputChanged,
+			}, {
+				Left = e("Frame", {
+					Position = UDim2.fromScale(0, 0),
+					Size = UDim2.new(self.state.alpha, -HANDLE_WIDTH / 2, 1, 0),
+					BackgroundTransparency = 1,
+					ZIndex = 0,
+				}, { self.props[Roact.Children].Left }),
+				Right = e("Frame", {
+					AnchorPoint = Vector2.new(1, 0),
+					Position = UDim2.fromScale(1, 0),
+					Size = UDim2.new(1 - self.state.alpha, -HANDLE_WIDTH / 2, 1, 0),
+					BackgroundTransparency = 1,
+					ZIndex = 0,
+				}, { self.props[Roact.Children].Right }),
+				Grabber = e("TextButton", {
+					AutoButtonColor = false,
+					Text = "",
+					AnchorPoint = Vector2.new(0.5, 0),
+					Position = UDim2.fromScale(self.state.alpha, 0),
+					Size = UDim2.new(0, HANDLE_WIDTH, 1, 0),
+					BackgroundColor3 = theme:GetColor("DialogButtonBorder"),
+					BorderSizePixel = 0,
+					ZIndex = 1,
+					[Roact.Event.InputBegan] = self.onInputBegan,
+					[Roact.Event.InputEnded] = self.onInputEnded,
+				}, {
+					BorderLeft = e("Frame", {
+						Position = UDim2.fromOffset(-1, 0),
+						Size = UDim2.new(0, 1, 1, 0),
+						BackgroundColor3 = theme:GetColor("ScriptRuler"),
+						BorderSizePixel = 0,
+						Visible = self.state.hovering or self.state.dragging,
+					}),
+					BorderRight = e("Frame", {
+						Position = UDim2.fromScale(1, 0),
+						Size = UDim2.new(0, 1, 1, 0),
+						BackgroundColor3 = theme:GetColor("ScriptRuler"),
+						BorderSizePixel = 0,
+						Visible = self.state.hovering or self.state.dragging,
+					}),
+				}),
+			})
+		end,
+	})
+end
+
+return VerticalSplitter

--- a/src/Loader.server.lua
+++ b/src/Loader.server.lua
@@ -101,6 +101,13 @@ function PluginFacade:createDockWidgetPluginGui(name, ...)
 end
 
 --[[
+	Wrapper around plugin:GetMouse
+]]
+function PluginFacade:getMouse()
+	return plugin:GetMouse()
+end
+
+--[[
 	Sets the method to call the next time the system tries to reload
 ]]
 function PluginFacade:beforeUnload(callback)

--- a/src/Main.lua
+++ b/src/Main.lua
@@ -1,4 +1,4 @@
-local RunService = game:GetService('RunService')
+local RunService = game:GetService("RunService")
 
 local Hoarcekat = script:FindFirstAncestor("Hoarcekat")
 
@@ -21,12 +21,7 @@ local function Main(plugin, savedState)
 	local displaySuffix, nameSuffix = getSuffix(plugin)
 	local toolbar = plugin:toolbar("Hoarcekat" .. displaySuffix)
 
-	local toggleButton = plugin:button(
-		toolbar,
-		"Hoarcekat",
-		"Open the Hoarcekat window",
-		"rbxassetid://4621571957"
-	)
+	local toggleButton = plugin:button(toolbar, "Hoarcekat", "Open the Hoarcekat window", "rbxassetid://4621571957")
 
 	local store = Rodux.Store.new(Reducer, savedState)
 
@@ -45,7 +40,9 @@ local function Main(plugin, savedState)
 	local app = Roact.createElement(RoactRodux.StoreProvider, {
 		store = store,
 	}, {
-		App = Roact.createElement(App),
+		App = Roact.createElement(App, {
+			Mouse = plugin:getMouse(),
+		}),
 	})
 
 	local instance = Roact.mount(app, gui, "Hoarcekat")
@@ -56,7 +53,9 @@ local function Main(plugin, savedState)
 		return store:getState()
 	end)
 
-	if RunService:IsRunning() then return end
+	if RunService:IsRunning() then
+		return
+	end
 
 	local unloadConnection
 	unloadConnection = gui.AncestryChanged:Connect(function()


### PR DESCRIPTION
This PR adds a vertical splitter control in between the Stories list and the Preview pane. Clicking and dragging this bar lets you resize the two panels, for example to maximize preview space or to view more of a deeply indented list at once.

https://user-images.githubusercontent.com/25118482/186950270-9429352e-d4f8-49aa-b070-80430330a417.mp4

NB: the horizontal scroller in the Stories list exhibits some weird behavior when you expand and then shrink the stories area. Looks like this behavior was already present so wasn't introduced in this change, just made more obvious. That behavior can be repro'd on existing version by resizing whole widget to be wider and then smaller again.
