### PR TITLE
Move preview toggle button to top

### DIFF
--- a/src/Components/Preview.lua
+++ b/src/Components/Preview.lua
@@ -224,7 +224,7 @@ function Preview:render()
 		ExpandButton = e("Frame", {
 			AnchorPoint = Vector2.new(1, 1),
 			BackgroundTransparency = 1,
-			Position = UDim2.new(0.99, -45, 0.99),
+			Position = UDim2.new(.99, 0, 0.99,-44),
 			Size = UDim2.fromOffset(40, 40),
 			ZIndex = 2,
 		}, {


### PR DESCRIPTION
This PR moves preview toggle button to top of selection button 

![image](https://github.com/Kampfkarren/hoarcekat/assets/34089907/d19835b7-3d8e-4e12-954e-0664fc6f7cee)

it is easier to use split panes when the plugin widget viewport is minimal